### PR TITLE
Update usage examples with more versatile examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ cache:
 
 install:
 # code coverage can't run in less than 0.12 -- exact reason why this tool was written
-- node ./index.js -gt 0.12 && npm install codacy-coverage istanbul -g || return 0
+- node ./index.js -gt 0.12 || exit 0; npm install codacy-coverage istanbul -g
 
 script:
 # run unit tests
@@ -32,7 +32,7 @@ script:
 - node ./index.js -lt 100000000
 
 # code coverage and upload to codacy (can't run in less than 0.12)
-- (node ./index.js -gt 0.12 && istanbul cover test.js --report lcovonly && cat ./coverage/lcov.info | codacy-coverage) || return 0
+- (node ./index.js -gt 0.12 || exit 0; istanbul cover test.js --report lcovonly && cat ./coverage/lcov.info | codacy-coverage)
 
 deploy:
   provider: npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ cache:
   - $HOME/.nvm
 
 install:
-# code coverage can't run in less than 0.12 -- exact reason why this tool was written
-- node ./index.js -gt 0.12 || exit 0; npm install codacy-coverage istanbul -g
+# code coverage can't run in less than 6 -- exact reason why this tool was written
+- node ./index.js -gt 6 || exit 0; npm install codacy-coverage istanbul -g
 
 script:
 # run unit tests
@@ -31,8 +31,8 @@ script:
 - node ./index.js -gt 0.1
 - node ./index.js -lt 100000000
 
-# code coverage and upload to codacy (can't run in less than 0.12)
-- (node ./index.js -gt 0.12 || exit 0; istanbul cover test.js --report lcovonly && cat ./coverage/lcov.info | codacy-coverage)
+# code coverage and upload to codacy (can't run in less than 6)
+- (node ./index.js -gt 6 || exit 0; istanbul cover test.js --report lcovonly && cat ./coverage/lcov.info | codacy-coverage)
 
 deploy:
   provider: npm

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Description
 
-Check installed node version against a requested version using an comparison operator. 
+Check installed node version against a requested version using an comparison operator.
 The main purpose of this script is make it easier to only run scripts if the node version is correct.
 This is meant to be simple and have zero dependencies, so that it will be very exportable and versatile.
 
@@ -27,13 +27,14 @@ yarn add if-ver --dev
 
 ## Usage
 
-```
+```bash
 if-ver [comparison-operator] [semantic-version]
 ```
 
-``` json
+### package.json usage
+```json
 "scripts": {
-  "test": "if-ver -gt 4 && run-node-4-thing || return 0"
+  "test": "if-ver -gt 4 || exit 0; run-node-4-thing"
 }
 ```
 
@@ -51,29 +52,29 @@ Similar to the bash comparision operators:
 ## Examples:
 
   Only run eslint if node version is at least 4 (else do nothing):
-  ``` json
+  ```json
   "scripts": {
-    "lint": "if-ver -gt 4 && eslint *.js || return 0"
+    "lint": "if-ver -gt 4 || exit 0; eslint *.js"
   }
   ```
 
   Only compile typescript if node version is at least 4.2 (else do nothing):
-  ``` json
+  ```json
   "scripts": {
-    "build": "if-ver -gt 4.2 && tsc || return 0"
+    "build": "if-ver -gt 4.2 || exit 0; tsc"
   }
   ```
 
   Only run webpack if node version is (>= 4.3 && <5) || > 5.10 (else do nothing):
-  ``` json
+  ```json
   "scripts": {
-    "build": "(if-ver -ge 4.3 && if-ver -lt 5) || if-ver -gt 5.10) && webpack || return 0"
+    "build": "(if-ver -ge 4.3 && if-ver -lt 5) || if-ver -gt 5.10) || exit 0; webpack"
   }
   ```
 
   Only run rollup if node version is >= 0.12 (else do nothing):
-  ``` json
+  ```json
   "scripts": {
-    "build": "if-ver -ge 0.12 && rollup -c || return 0"
+    "build": "if-ver -ge 0.12 || exit 0; rollup -c"
   }
   ```

--- a/usage.txt
+++ b/usage.txt
@@ -1,6 +1,6 @@
 Usage: if-ver [comparison-operator] [semantic-version]
 
-Check installed node version against a requested version using comparison operator. 
+Check installed node version against a requested version using comparison operator.
 The main purpose of this script is make it easier to only run scripts if the version is correct.
 
 Comparison operators:
@@ -15,12 +15,12 @@ Examples:
 
   Only run eslint if node version is at least 4:
 
-  if-ver -ge 4 && eslint *.js
+  if-ver -ge 4 || exit 0; eslint *.js
 
   Only compile typescript if node version is at least 4.2:
 
-  if-ver -ge 4.2 && tsc
+  if-ver -ge 4.2 || exit 0; tsc
 
   Only run webpack if node version is (>= 4.3 && <5) || > 5.10:
 
-  (if-ver -ge 4.3 && if-ver -lt 5) || if-ver -gt 5.10) && webpack
+  (if-ver -ge 4.3 && if-ver -lt 5) || if-ver -gt 5.10) || exit 0; webpack


### PR DESCRIPTION
As @jaydenseric suggested in #8, `|| exit 0` is a better usage than `|| return 0` on the end of a command.

`|| return 0` will swallow errors from the command and won't tell the user if the execution failed or not.